### PR TITLE
Ignore encoding errors when reading JSON files

### DIFF
--- a/pizero_gpslog/converter.py
+++ b/pizero_gpslog/converter.py
@@ -55,7 +55,7 @@ class GpxConverter(object):
 
     def convert(self):
         logs = []
-        with open(self._in_fpath, 'r') as fh:
+        with open(self._in_fpath, 'r', errors='ignore') as fh:
             lineno = 0
             for line in fh.readlines():
                 lineno += 1


### PR DESCRIPTION
Hi Jason,

this project is exactly what I've been looking for and I was close to writing my own until I discovered this repo. It seems to work great so far. Here is one small problem I have noticed though.

File corruption on some cheap SD-Cards can lead to UTF-8 errors in the JSON files. When converting such files, the convert utility might crash:
```
$ pizero-gpslog-convert 2020-07-27_14-52-39.json
Traceback (most recent call last):
  File "/usr/local/bin/pizero-gpslog-convert", line 11, in <module>
    load_entry_point('pizero-gpslog', 'console_scripts', 'pizero-gpslog-convert')()
  File "/home/pi/pizero-gpslog/pizero_gpslog/converter.py", line 213, in main
    gpx = conv.convert()
  File "/home/pi/pizero-gpslog/pizero_gpslog/converter.py", line 60, in convert
    for line in fh.readlines():
  File "/usr/lib/python3.7/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xb4 in position 2096: invalid start byte
```

By simply ignoring these errors, such files can still be converted, with the affected line being skipped due to JSON decode errors:
```
$ pizero-gpslog-convert 2020-07-27_14-52-39.json
Unable to decode JSON on line 3831; skipping. (ERROR: Invalid control character at: line 1 column 805 (char 804))
Unable to decode JSON on line 3832; skipping. (ERROR: Expecting property name enclosed in double quotes: line 1 column 68 (char 67))
[ many many more errors... ]
Unable to decode JSON on line 4159; skipping. (ERROR: Expecting property name enclosed in double quotes: line 1 column 53 (char 52))
Unable to decode JSON on line 4160; skipping. (ERROR: Expecting ',' delimiter: line 1 column 17 (char 16))
Unable to decode JSON on line 4161; skipping. (ERROR: Invalid control character at: line 1 column 40 (char 39))
Unable to decode JSON on line 4162; skipping. (ERROR: Invalid control character at: line 1 column 82 (char 81))
Track Start: 2020-07-27 14:52:39+00:00 UTC
Track End: 2020-07-27 22:16:37+00:00 UTC
Track Duration: 7h 23m 58s
5249 points in track
Moving time: 2h 2m 45s
Stopped time: 5h 21m 8s
Max Speed: 17.5017 m/s
2D (Horizontal) distance: 66931.5714 m
Total elevation increase: 4797.1159 m
Total elevation decrease: 4769.0849 m
Minimum elevation: -49.2960 m
Maximum elevation: 98.7730 m

GPX file written to: 2020-07-27_14-52-39.gpx
```

It's a very simple fix which can still lead to wrong gpx-files, but at least it can recover whats still there. Now I just have to buy some new SD-cards 🙄

Thank you!